### PR TITLE
Update mobile-feature-comparison.md

### DIFF
--- a/Skype/SfbServer/plan-your-deployment/clients-and-devices/mobile-feature-comparison.md
+++ b/Skype/SfbServer/plan-your-deployment/clients-and-devices/mobile-feature-comparison.md
@@ -173,7 +173,7 @@ On iOS devices, Skype for Business signs out automatically after the mobile clie
   
  &#x2777;  Requires a WiFi connection by default.
  
-  &#x2778; Viewing embedded video in PowerPoint presentations is not supported.
+ &#x2778; Viewing embedded video in PowerPoint presentations is not supported.
   
 ## Telephony support
 


### PR DESCRIPTION

* Added number 3 to IOS and Android under "View shared PowerPoint files" with a note that states, "Viewing embedded video in PowerPoint presentations is not supported."

See UserVoice:
The ios Skype for business client (Phone and ipad) does not play videos embedded in PowerPoint. This has been confirmed by Microsoft support
https://www.skypefeedback.com/forums/299913-generally-available/suggestions/31537219-the-ios-skype-for-business-client-phone-and-ipad

https://www.skypefeedback.com/forums/299913-generally-available/suggestions/35314720-powerpoint-sharing-error-in-android-app